### PR TITLE
Add support for Darwin/arm64

### DIFF
--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
     - windows
     - darwin
     goarch:
+    - arm64
     - amd64
     - "386"
     env:

--- a/deploy/krew/df-pv.yaml
+++ b/deploy/krew/df-pv.yaml
@@ -19,6 +19,17 @@ spec:
   - selector:
       matchLabels:
         os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/yashbhutwala/kubectl-df-pv/releases/download/{{ .TagName }}/kubectl-df-pv_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    files:
+    - from: "df-pv"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "df-pv"
+  - selector:
+      matchLabels:
+        os: darwin
         arch: amd64
     {{addURIAndSha "https://github.com/yashbhutwala/kubectl-df-pv/releases/download/{{ .TagName }}/kubectl-df-pv_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
     files:


### PR DESCRIPTION
This PR adds support for M1 Macbooks for both the GitHub releases and `krew`.