### PR TITLE
Fixing disk usage color

### DIFF
--- a/pkg/df-pv/root.go
+++ b/pkg/df-pv/root.go
@@ -140,9 +140,9 @@ func GetColorFromPercentageUsed(percentageUsed float64) text.Color {
 	if percentageUsed > 75 {
 		return text.FgRed
 	} else if percentageUsed < 25 {
-		return text.FgYellow
-	} else {
 		return text.FgGreen
+	} else {
+		return text.FgYellow
 	}
 }
 


### PR DESCRIPTION
The color should be yellow if disk usage is less than 75% and green if disk usage is less than 25%