### PR TITLE
fix: skip empty node names to prevent panic

### DIFF
--- a/pkg/df-pv/root.go
+++ b/pkg/df-pv/root.go
@@ -423,6 +423,9 @@ func ConsumeOutputRowsConcurrently(outputRowPVCChan <-chan *OutputRowPVC) []*Out
 
 // ProduceOutputRowsConcurrently produces output rows concurrently
 func ProduceOutputRowsConcurrently(ctx context.Context, clientset *kubernetes.Clientset, desiredNamespace string, nodeNames []string, outputRowPVCChan chan<- *OutputRowPVC) error {
+	producerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var producerGroup run.Group
 	for _, nodeName := range nodeNames {
 		nodeName := nodeName
@@ -431,18 +434,17 @@ func ProduceOutputRowsConcurrently(ctx context.Context, clientset *kubernetes.Cl
 			continue
 		}
 		producerGroup.Add(func() error {
-			return GetOutputRowPVCFromNode(ctx, clientset, desiredNamespace, nodeName, outputRowPVCChan)
+			return GetOutputRowPVCFromNode(producerCtx, clientset, desiredNamespace, nodeName, outputRowPVCChan)
 		}, func(err error) {
 			if err != nil {
+				cancel()
 				log.Infof("TODO goroutine error handling; current actor was interrupted with: %v\n", err)
 			}
 		})
 	}
-	if err := producerGroup.Run(); err != nil {
-		return err
-	}
+	err := producerGroup.Run()
 	close(outputRowPVCChan)
-	return nil
+	return err
 }
 
 // GetOutputRowPVCFromNode gets the output row given a nodeName

--- a/pkg/df-pv/root.go
+++ b/pkg/df-pv/root.go
@@ -30,18 +30,18 @@ import (
 
 // IEC (binary) byte size constants for readability
 const (
-    kibibyte int64 = 1 << 10
-    mebibyte int64 = 1 << 20
-    gibibyte int64 = 1 << 30
-    tebibyte int64 = 1 << 40
+	kibibyte int64 = 1 << 10
+	mebibyte int64 = 1 << 20
+	gibibyte int64 = 1 << 30
+	tebibyte int64 = 1 << 40
 )
 
 // Decimal (SI) byte size constants for readability
 const (
-    kilobyte int64 = 1000
-    megabyte int64 = 1000 * kilobyte
-    gigabyte int64 = 1000 * megabyte
-    terabyte int64 = 1000 * gigabyte
+	kilobyte int64 = 1000
+	megabyte int64 = 1000 * kilobyte
+	gigabyte int64 = 1000 * megabyte
+	terabyte int64 = 1000 * gigabyte
 )
 
 // InitAndExecute sets up and executes the cobra root command
@@ -177,56 +177,56 @@ func GetColorFromPercentageUsed(percentageUsed float64) text.Color {
 // ConvertQuantityValueToHumanReadableIECString converts value to human readable IEC format
 // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 func ConvertQuantityValueToHumanReadableIECString(quantity *resource.Quantity) string {
-    bytes := quantity.Value()
-    if bytes < 0 {
-        bytes = 0
-    }
+	bytes := quantity.Value()
+	if bytes < 0 {
+		bytes = 0
+	}
 
-    var val float64
-    var suffix string
+	var val float64
+	var suffix string
 
-    switch {
-    case bytes >= tebibyte:
-        val = float64(bytes) / float64(tebibyte)
-        suffix = "Ti"
-    case bytes >= gibibyte:
-        val = float64(bytes) / float64(gibibyte)
-        suffix = "Gi"
-    case bytes >= mebibyte:
-        val = float64(bytes) / float64(mebibyte)
-        suffix = "Mi"
-    case bytes >= kibibyte:
-        val = float64(bytes) / float64(kibibyte)
-        suffix = "Ki"
-    default:
-        return fmt.Sprintf("%d", bytes)
-    }
+	switch {
+	case bytes >= tebibyte:
+		val = float64(bytes) / float64(tebibyte)
+		suffix = "Ti"
+	case bytes >= gibibyte:
+		val = float64(bytes) / float64(gibibyte)
+		suffix = "Gi"
+	case bytes >= mebibyte:
+		val = float64(bytes) / float64(mebibyte)
+		suffix = "Mi"
+	case bytes >= kibibyte:
+		val = float64(bytes) / float64(kibibyte)
+		suffix = "Ki"
+	default:
+		return fmt.Sprintf("%d", bytes)
+	}
 
-    // strip trailing zeroes, then strip decimal if not needed
-    strVal := strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", val), "0"), ".")
-    return fmt.Sprintf("%s%s", strVal, suffix)
+	// strip trailing zeroes, then strip decimal if not needed
+	strVal := strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", val), "0"), ".")
+	return fmt.Sprintf("%s%s", strVal, suffix)
 }
 
 // ConvertQuantityValueToHumanReadableDecimalString converts value to human readable decimal format
 func ConvertQuantityValueToHumanReadableDecimalString(quantity *resource.Quantity) string {
-    val := quantity.Value()
+	val := quantity.Value()
 
-    TBConvertedVal := val / terabyte
-    GBConvertedVal := val / gigabyte
-    MBConvertedVal := val / megabyte
-    KBConvertedVal := val / kilobyte
+	TBConvertedVal := val / terabyte
+	GBConvertedVal := val / gigabyte
+	MBConvertedVal := val / megabyte
+	KBConvertedVal := val / kilobyte
 
-    if TBConvertedVal > 1 {
-        return fmt.Sprintf("%d%s", TBConvertedVal, "TB")
-    } else if GBConvertedVal > 1 {
-        return fmt.Sprintf("%d%s", GBConvertedVal, "GB")
-    } else if MBConvertedVal > 1 {
-        return fmt.Sprintf("%d%s", MBConvertedVal, "MB")
-    } else if KBConvertedVal > 1 {
-        return fmt.Sprintf("%d%s", KBConvertedVal, "KB")
-    } else {
-        return fmt.Sprintf("%d", val)
-    }
+	if TBConvertedVal > 1 {
+		return fmt.Sprintf("%d%s", TBConvertedVal, "TB")
+	} else if GBConvertedVal > 1 {
+		return fmt.Sprintf("%d%s", GBConvertedVal, "GB")
+	} else if MBConvertedVal > 1 {
+		return fmt.Sprintf("%d%s", MBConvertedVal, "MB")
+	} else if KBConvertedVal > 1 {
+		return fmt.Sprintf("%d%s", KBConvertedVal, "KB")
+	} else {
+		return fmt.Sprintf("%d", val)
+	}
 }
 
 // OutputRowPVC represents the output row
@@ -426,6 +426,10 @@ func ProduceOutputRowsConcurrently(ctx context.Context, clientset *kubernetes.Cl
 	var producerGroup run.Group
 	for _, nodeName := range nodeNames {
 		nodeName := nodeName
+		if nodeName == "" {
+			log.Warnf("skipping empty node name")
+			continue
+		}
 		producerGroup.Add(func() error {
 			return GetOutputRowPVCFromNode(ctx, clientset, desiredNamespace, nodeName, outputRowPVCChan)
 		}, func(err error) {

--- a/pkg/df-pv/root_test.go
+++ b/pkg/df-pv/root_test.go
@@ -1,34 +1,122 @@
 package df_pv
 
 import (
-    "testing"
-    "k8s.io/apimachinery/pkg/api/resource"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 func TestConvertQuantityValueToHumanReadableIECString(t *testing.T) {
-    tests := []struct {
-        name  string
-        bytes int64
-        want  string
-    }{
-        {name: "zero", bytes: 0, want: "0"},
-        {name: "lt_1Ki", bytes: 512, want: "512"},
-        {name: "eq_1Ki", bytes: 1 << 10, want: "1Ki"},
-        {name: "one_point_five_Ki", bytes: 1536, want: "1.5Ki"},
-        {name: "eq_1Mi", bytes: 1 << 20, want: "1Mi"},
-        {name: "eq_1Gi", bytes: 1 << 30, want: "1Gi"},
-        {name: "one_point_five_Gi", bytes: (1 << 30) + (512 << 20), want: "1.5Gi"},
-        {name: "eq_1Ti", bytes: 1 << 40, want: "1Ti"},
-    }
+	tests := []struct {
+		name  string
+		bytes int64
+		want  string
+	}{
+		{name: "zero", bytes: 0, want: "0"},
+		{name: "lt_1Ki", bytes: 512, want: "512"},
+		{name: "eq_1Ki", bytes: 1 << 10, want: "1Ki"},
+		{name: "one_point_five_Ki", bytes: 1536, want: "1.5Ki"},
+		{name: "eq_1Mi", bytes: 1 << 20, want: "1Mi"},
+		{name: "eq_1Gi", bytes: 1 << 30, want: "1Gi"},
+		{name: "one_point_five_Gi", bytes: (1 << 30) + (512 << 20), want: "1.5Gi"},
+		{name: "eq_1Ti", bytes: 1 << 40, want: "1Ti"},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            q := resource.NewQuantity(tt.bytes, resource.BinarySI)
-            got := ConvertQuantityValueToHumanReadableIECString(q)
-            if got != tt.want {
-                t.Fatalf("ConvertQuantityValueToHumanReadableIECString(%d) = %q, want %q", tt.bytes, got, tt.want)
-            }
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := resource.NewQuantity(tt.bytes, resource.BinarySI)
+			got := ConvertQuantityValueToHumanReadableIECString(q)
+			if got != tt.want {
+				t.Fatalf("ConvertQuantityValueToHumanReadableIECString(%d) = %q, want %q", tt.bytes, got, tt.want)
+			}
+		})
+	}
 }
 
+func TestProduceOutputRowsConcurrentlySkipsEmptyNodeNames(t *testing.T) {
+	clientset, requestCount := newTestClientset(t, http.StatusInternalServerError)
+	outputRowPVCChan := make(chan *OutputRowPVC)
+	result := make(chan error, 1)
+
+	go func() {
+		result <- ProduceOutputRowsConcurrently(context.Background(), clientset, "", []string{""}, outputRowPVCChan)
+	}()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("ProduceOutputRowsConcurrently returned an unexpected error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ProduceOutputRowsConcurrently did not return for an empty node name")
+	}
+
+	select {
+	case _, ok := <-outputRowPVCChan:
+		if ok {
+			t.Fatal("output row channel should be closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("output row channel was not closed")
+	}
+
+	if *requestCount != 0 {
+		t.Fatalf("expected no node stats requests, got %d", *requestCount)
+	}
+}
+
+func TestProduceOutputRowsConcurrentlyClosesChannelOnNodeError(t *testing.T) {
+	clientset, requestCount := newTestClientset(t, http.StatusInternalServerError)
+	outputRowPVCChan := make(chan *OutputRowPVC)
+	result := make(chan error, 1)
+
+	go func() {
+		result <- ProduceOutputRowsConcurrently(context.Background(), clientset, "", []string{"node-a"}, outputRowPVCChan)
+	}()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("ProduceOutputRowsConcurrently returned nil for a node request error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ProduceOutputRowsConcurrently did not return after a node request error")
+	}
+
+	select {
+	case _, ok := <-outputRowPVCChan:
+		if ok {
+			t.Fatal("output row channel should be closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("output row channel was not closed after a node request error")
+	}
+
+	if *requestCount != 1 {
+		t.Fatalf("expected one node stats request, got %d", *requestCount)
+	}
+}
+
+func newTestClientset(t *testing.T, statusCode int) (*kubernetes.Clientset, *int) {
+	t.Helper()
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		http.Error(w, "test node error", statusCode)
+	}))
+	t.Cleanup(server.Close)
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("failed to create test clientset: %v", err)
+	}
+
+	return clientset, &requestCount
+}


### PR DESCRIPTION
Fixes #17

When nodeName is empty, the API request fails with 'resource name may not be empty'. Skip empty node names with a warning instead of propagating the error.